### PR TITLE
Hotfix: Wrong condition on sempahore

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,3 @@
-
 // Semaphores
 
 function Semaphore(initialCount) {
@@ -10,7 +9,7 @@ function Semaphore(initialCount) {
 Semaphore.prototype.signal = function () {
 	this._count += 1;
 
-	if (this._count > 0) {
+	if (this._count <= 0) {
 		var waiter = this._waiting.shift();
 		if (waiter) {
 			waiter();


### PR DESCRIPTION
Fixing wrong condition on semaphore which was leading to deadlock. 
You can reproduce error by creating Semaphore(1), 3x call wait(), 1x call signal() and you will get deadlock(you will not release one lock). Expected result is to release one of two other wait locks. 

For semaphore references: 
http://www.cs.jhu.edu/~yairamir/cs418/os3/sld019.htm

http://en.wikibooks.org/wiki/Operating_System_Design/Processes/Semaphores