### PR TITLE
Mutex:  timed lock error.

### DIFF
--- a/index.js
+++ b/index.js
@@ -91,13 +91,13 @@ Mutex.prototype.timedLock = function (ttl, cb) {
 	this._waiting.push(function () {
 		clearTimeout(timer);
 
-		if (cb) {
-			cb();
-			cb = null;
+		if (!cb) {
+			that.unlock();
 			return;
 		}
 
-		that.unlock();
+		cb();
+		cb = null;
 	});
 
 	timer = setTimeout(function () {
@@ -175,12 +175,13 @@ ReadWriteLock.prototype.timedReadLock = function (ttl, cb) {
 	this._waitingToRead.push(function () {
 		clearTimeout(timer);
 
-		if (cb) {
-			cb();
-			cb = null;
+		if (!cb) {
+			that.unlock();
+			return;
 		}
 
-		that.unlock();
+		cb();
+		cb = null;
 	});
 
 	timer = setTimeout(function () {
@@ -202,12 +203,13 @@ ReadWriteLock.prototype.timedWriteLock = function (ttl, cb) {
 	this._waitingToWrite.push(function () {
 		clearTimeout(timer);
 
-		if (cb) {
-			cb();
-			cb = null;
+		if (!cb) {
+			that.unlock();
+			return;
 		}
 
-		that.unlock();
+		cb();
+		cb = null;
 	});
 
 	timer = setTimeout(function () {


### PR DESCRIPTION
I found that the timed_lock request was sometimes issuing a success callback, but unlocking the Mutex.  The problem only occurs when the _waiting handler is called before the timeout expires.
