### PR TITLE
Allow conditions to be non-functions.

### DIFF
--- a/lib/CondVariable.js
+++ b/lib/CondVariable.js
@@ -6,12 +6,40 @@ function CondVariable(initialValue) {
 module.exports = CondVariable;
 
 
-CondVariable.prototype.wait = function (fnTest, cb) {
-	if (fnTest(this._value)) {
-		return cb();
+function condToFunc(cond) {
+	if (typeof cond === 'function') {
+		return cond;
 	}
 
-	this._waiting.push({ fnTest: fnTest, cb: cb });
+	if (typeof cond === 'number' || typeof cond === 'boolean' || typeof cond === 'string') {
+		return function (value) {
+			return value === cond;
+		};
+	}
+
+	if (cond && typeof cond === 'object' && cond instanceof RegExp) {
+		return function (value) {
+			return cond.test(value);
+		};
+	}
+
+	throw new TypeError('Unknown condition type: ' + (typeof cond));
+}
+
+
+CondVariable.prototype.get = function () {
+	return this._value;
+};
+
+
+CondVariable.prototype.wait = function (cond, cb) {
+	var test = condToFunc(cond);
+
+	if (test(this._value)) {
+		return cb.call(this);
+	}
+
+	this._waiting.push({ test: test, cb: cb });
 };
 
 
@@ -21,10 +49,10 @@ CondVariable.prototype.set = function (value) {
 	for (var i = 0; i < this._waiting.length; i++) {
 		var waiter = this._waiting[i];
 
-		if (waiter.fnTest(value)) {
-			waiter.cb();
+		if (waiter.test(value)) {
 			this._waiting.splice(i, 1);
 			i -= 1;
+			waiter.cb.call(this);
 		}
 	}
 };

--- a/test/condvariable.js
+++ b/test/condvariable.js
@@ -1,0 +1,60 @@
+var locks = require('..');
+var test = require('tape');
+
+var trueTest = function (value) { return value === true; };
+var falseTest = function (value) { return value === false; };
+
+
+test('CondVariable', function (t) {
+	var cond = locks.createCondVariable(false);
+	var timerFired = false;
+
+	t.equal(cond.get(), false, 'Condition starts false');
+
+	cond.wait(trueTest, function () {
+		t.equal(this.get(), true, 'Condition is true');
+
+		cond.set(null);
+
+		var fired = 0;
+		var expect = 4;
+
+		cond.wait('foo', function () {
+			t.equal(this.get(), 'foo', 'String matching');
+			fired += 1;
+		});
+
+		cond.wait(/foo/, function () {
+			t.equal(this.get(), 'foo', 'RegExp matching');
+			fired += 1;
+		});
+
+		cond.wait(5, function () {
+			t.equal(this.get(), 5, 'Number matching');
+			fired += 1;
+		});
+
+		cond.wait(false, function () {
+			t.equal(this.get(), false, 'Boolean matching');
+			fired += 1;
+		});
+
+		cond.set('foo');
+		cond.set(5);
+		cond.set(false);
+
+		t.equal(fired, 4, 'All match types fired');
+
+		t.end();
+	});
+
+	cond.wait(falseTest, function () {
+		t.equal(this.get(), false, 'Condition is false');
+		t.equal(timerFired, false, 'Timer has not yet fired');
+	});
+
+	setTimeout(function () {
+		timerFired = true;
+		cond.set(true);
+	}, 10);
+});


### PR DESCRIPTION
This allows values in Condition Variables to not just be functions, but also strings, numbers, booleans and regular expressions. These are all turned into functions that do literal matching (or in the case of regexp, runs an `re.test`).

Also added unit tests for Condition Variables and added a `get()` API on cond vars to get the current value.